### PR TITLE
Add corrosion resistant cargo modules to cargoCap sum.

### DIFF
--- a/load.py
+++ b/load.py
@@ -137,6 +137,12 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
 				cargoCap += 128
 			elif state['Modules'][i]['Item'] == 'int_cargorack_size8_class1':
 				cargoCap += 256
+			elif state['Modules'][i]['Item'] == 'int_corrosionproofcargorack_size1_class1':
+				cargoCap += 1
+			elif state['Modules'][i]['Item'] == 'int_corrosionproofcargorack_size1_class2':
+				cargoCap += 2
+			elif state['Modules'][i]['Item'] == 'int_corrosionproofcargorack_size4_class1':
+				cargoCap += 16
 
 		this.cargoCapacity = cargoCap
 		update_display()


### PR DESCRIPTION
Adds 1E (1t), 1F (2t), and 4E (16t) Corrosion Resistant cargo modules to the calculation for the capacity total.